### PR TITLE
update grunt-concurrent package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gruntfile-gtx",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Turbo, spoilers and a sunroof for your Gruntfile",
   "author": {
     "name": "Bart van der Schoor",
@@ -38,13 +38,13 @@
   },
   "dependencies": {
     "load-grunt-tasks": "~0.2.0",
-    "grunt-concurrent": "~0.4.3"
+    "grunt-concurrent": "~0.5.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",
     "mkdirp": "0.3.5",
     "grunt-cli": "~0.1",
-    "grunt-concurrent": "~0.4.0",
+    "grunt-concurrent": "~0.5.0",
     "grunt-wait": "~0.1.0",
     "grunt-mocha-test": "~0.5.0",
     "mocha-unfunk-reporter": "~0.2",


### PR DESCRIPTION
- without this update, an `npm shrinkwrap` of a package with `gruntfile-gtx` as a dependency (and a newer version of `grunt` installed?) will fail with the following:
  
  ```
  npm ERR! Error: Problems were encountered
  npm ERR! Please correct and try again.
  npm ERR! missing: grunt@~0.4.0, required by grunt-concurrent@0.4.3
  npm ERR!     at shrinkwrap_ (/usr/local/lib/node_modules/npm/lib/shrinkwrap.js:30:15)
  npm ERR!     at /usr/local/lib/node_modules/npm/lib/shrinkwrap.js:24:5
  npm ERR!     at /usr/local/lib/node_modules/npm/lib/ls.js:44:30
  npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-installed/read-installed.js:130:5
  npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-installed/read-installed.js:258:14
  npm ERR!     at cb (/usr/local/lib/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
  npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-installed/read-installed.js:258:14
  npm ERR!     at cb (/usr/local/lib/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
  npm ERR!     at /usr/local/lib/node_modules/npm/node_modules/read-installed/read-installed.js:258:14
  npm ERR!     at cb (/usr/local/lib/node_modules/npm/node_modules/slide/lib/async-map.js:48:11)
  npm ERR! If you need help, you may report this *entire* log,
  npm ERR! including the npm and node versions, at:
  npm ERR!     <http://github.com/npm/npm/issues>
  
  npm ERR! System Darwin 13.1.0
  npm ERR! command "node" "/usr/local/bin/npm" "shrinkwrap"
  npm ERR! cwd /Volumes/samara/projects/decipher/core/beacon
  npm ERR! node -v v0.10.28
  npm ERR! npm -v 1.4.9
  npm ERR!
  npm ERR! Additional logging details can be found in:
  npm ERR!     /Volumes/samara/projects/decipher/core/beacon/npm-debug.log
  npm ERR! not ok code 0
  ```
  
  It's a mystery to me why this would happen exactly, but the problem may be either the mismatched versions of `grunt-concurrent` in `gruntfile-gtx`'s deps/devDeps, or with `grunt-concurrent` itself.
  
  Anyway, this fixes the issue.
